### PR TITLE
Fix uninitialized constant issue

### DIFF
--- a/lib/omniauth/instagram-graph/long_lived_client.rb
+++ b/lib/omniauth/instagram-graph/long_lived_client.rb
@@ -2,7 +2,7 @@
 
 module OmniAuth
   module InstagramGraph
-    class LongLivedClient < OAuth2::Client
+    class LongLivedClient < ::OAuth2::Client
       TOKEN_URL = '/access_token'
 
       def initialize(client_id, client_secret, options = {})

--- a/lib/omniauth/instagram-graph/long_lived_token.rb
+++ b/lib/omniauth/instagram-graph/long_lived_token.rb
@@ -2,7 +2,7 @@
 
 module OmniAuth
   module InstagramGraph
-    class LongLivedToken < OAuth2::AccessToken
+    class LongLivedToken < ::OAuth2::AccessToken
       TOKEN_REFRESH_PATH = '/refresh_access_token'
 
       def refresh!(params = {})


### PR DESCRIPTION
This PR modifies both LongLivedToken and LongLivedClient to prevent an uninitialized constant of `OmniAuth::OAuth2::AccessToken`