### PR TITLE
Allow for omniauth 2.0 series 

### DIFF
--- a/lib/omniauth/instagram-graph/version.rb
+++ b/lib/omniauth/instagram-graph/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module InstagramGraph
-    VERSION = '1.0.5'
+    VERSION = '2.0.0'
   end
 end

--- a/lib/omniauth/strategies/instagram-graph.rb
+++ b/lib/omniauth/strategies/instagram-graph.rb
@@ -54,7 +54,7 @@ module OmniAuth
       end
 
       def callback_url
-        options[:callback_url] || (full_host + script_name + callback_path)
+        options[:callback_url] || (full_host + callback_path)
       end
 
       # You can pass +scope+ param to the auth request, if you need to set them dynamically.

--- a/omniauth-instagram-graph.gemspec
+++ b/omniauth-instagram-graph.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'omniauth', '~> 1.9'
-  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.2'
+  spec.add_runtime_dependency 'omniauth', '~> 2.0'
+  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.7.1'
 
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'mocha'

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -23,3 +23,27 @@ class ClientTest < StrategyTestCase
     assert_equal 'https://api.instagram.com/oauth/access_token', strategy.client.token_url
   end
 end
+
+class CallbackUrlTest < StrategyTestCase
+  test "returns the default callback url" do
+    url_base = "http://example.com"
+    @request.stubs(:url).returns("#{url_base}/foo/")
+    strategy.stubs(:script_name).returns("") # as not to depend on Rack env
+    assert_equal "#{url_base}/auth/instagram_graph/callback", strategy.callback_url
+  end
+
+  test "returns path from callback_path option" do
+    @options = { :callback_path => "/callback/custom_path" }
+    url_base = "http://example.com"
+    @request.stubs(:url).returns("#{url_base}/foo/")
+    strategy.stubs(:script_name).returns("") # as not to depend on Rack env
+    assert_equal "#{url_base}/callback/custom_path", strategy.callback_url
+  end
+
+  test "returns callback_url when setting script_name" do
+    url_base = "http://example.com"
+    @request.stubs(:url).returns("#{url_base}/foo/")
+    strategy.stubs(:script_name).returns("/bar") # as not to depend on Rack env
+    assert_equal "#{url_base}/bar/auth/instagram_graph/callback", strategy.callback_url
+  end
+end


### PR DESCRIPTION
Hi, @igor-alexandrov 

OmniAuth 2.0 was released includes to resolved a CSRF vulnerability and some behaviors changed.

See below the release note for details.
https://github.com/omniauth/omniauth/releases/tag/v2.0.0

This PR allow for OmniAuth 2.0 series.

I tested manually in remote server with https communication environment, and confirmed following.
  - should use omniauth 2.0 series.
  - should return credentials in auth hash. (regression scenarios)

If you want to try my branch, you can use like following in your Gemfile.
```rb
gem 'omniauth-instagram-graph', github: 'koshilife/omniauth-instagram-graph', branch: 'allow-for-omniauth-2.0'
```